### PR TITLE
Add member actions for more flexible routes

### DIFF
--- a/system/refinery/routes.rb
+++ b/system/refinery/routes.rb
@@ -21,14 +21,7 @@ module Refinery
 
             resolver.new_action
 
-            resolver.with_key do |key|
-              resolver.edit_action(key)
-              resolver.delete_action(key)
-              resolver.update_action(key)
-              r.is do
-                resolver.show_action(key)
-              end
-            end
+            resolver.member
 
             r.is do
               resolver.index_action

--- a/system/refinery/routes/resolver.rb
+++ b/system/refinery/routes/resolver.rb
@@ -2,6 +2,7 @@
 
 require 'dry/core/inflector'
 require 'forwardable'
+
 module Refinery
   module Routes
     class Resolver
@@ -94,9 +95,18 @@ module Refinery
         end
       end
 
-      def with_key
+      def member
         r.on String do |id|
-          yield id
+          member_actions(id)
+        end
+      end
+
+      def member_actions(id)
+        edit_action(id)
+        delete_action(id)
+        update_action(id)
+        r.is do
+          show_action(id)
         end
       end
 


### PR DESCRIPTION
Prior to this change it has been impossible to add new routes to the
member actions without re-implementing `with_key`.

Now, `member_actions` can be overridden like:

```ruby
def member_actions(id)
  my_action(id)

  super
end
```